### PR TITLE
feat(tensor_utils): add batched image support to SaveTensor

### DIFF
--- a/nodes/tensor_utils/save_tensor.py
+++ b/nodes/tensor_utils/save_tensor.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch
 
 from comfystream import tensor_cache
@@ -21,6 +22,37 @@ class SaveTensor:
     def IS_CHANGED(s):
         return float("nan")
 
+    @staticmethod
+    def _split_images(images):
+        """Yield individual images for batched tensors/lists without changing interface."""
+        # Torch tensor inputs with optional batch dimension in dim 0
+        if isinstance(images, torch.Tensor):
+            if images.dim() >= 4 and images.shape[0] > 1:
+                for img in images:
+                    yield img
+                return
+            yield images
+            return
+
+        # Numpy arrays (should rarely occur, but handled for completeness)
+        if isinstance(images, np.ndarray):
+            if images.ndim >= 4 and images.shape[0] > 1:
+                for img in images:
+                    yield img
+                return
+            yield images
+            return
+
+        # Lists/tuples of images already separated
+        if isinstance(images, (list, tuple)):
+            for img in images:
+                yield img
+            return
+
+        # Fallback to passing through any other type as-is
+        yield images
+
     def execute(self, images: torch.Tensor):
-        tensor_cache.image_outputs.put_nowait(images)
+        for img in self._split_images(images):
+            tensor_cache.image_outputs.put_nowait(img)
         return images

--- a/test/test_save_tensor.py
+++ b/test/test_save_tensor.py
@@ -1,0 +1,46 @@
+import asyncio
+
+import pytest
+import torch
+
+from comfystream import tensor_cache
+from nodes.tensor_utils.save_tensor import SaveTensor
+
+
+async def _drain_image_queue():
+    while True:
+        try:
+            tensor_cache.image_outputs.get_nowait()
+        except asyncio.QueueEmpty:
+            break
+
+
+@pytest.mark.asyncio
+async def test_save_tensor_splits_batched_images():
+    await _drain_image_queue()
+
+    images = torch.rand(2, 8, 8, 3)
+
+    SaveTensor().execute(images)
+
+    first = await tensor_cache.image_outputs.get()
+    second = await tensor_cache.image_outputs.get()
+
+    assert torch.equal(first, images[0])
+    assert torch.equal(second, images[1])
+    assert tensor_cache.image_outputs.empty()
+
+
+@pytest.mark.asyncio
+async def test_save_tensor_passthrough_single_image():
+    await _drain_image_queue()
+
+    images = torch.rand(1, 4, 4, 3)
+
+    SaveTensor().execute(images)
+
+    queued = await tensor_cache.image_outputs.get()
+
+    assert torch.equal(queued, images)
+    assert tensor_cache.image_outputs.empty()
+


### PR DESCRIPTION
This change adds support for batched images in the `SaveTensor` node, allowing workflows to output multiple images using a workflow like [text-to-images.json](https://github.com/user-attachments/files/24321853/text-to-images.json)

<img width="1664" height="607" alt="image" src="https://github.com/user-attachments/assets/15d55422-c9d2-4665-8e24-648f758d903f" />
